### PR TITLE
Pagination not working correctly

### DIFF
--- a/src/components/TablePagination.jsx
+++ b/src/components/TablePagination.jsx
@@ -101,10 +101,10 @@ function TablePagination({
             First
           </a>
         </li>
-        {Array.from({ length: numberOfNavLinks }).map((item, i) => (
+        {Array.from({ length: paginationLinksNumber }).map((item, i) => (
           <li className="page-item disabled" key={i}>
             <a href="#" className="page-link">
-              {initialNumberOfNavigationLinks + i}
+              {paginationLinks + i}
             </a>
           </li>
         ))}
@@ -124,10 +124,10 @@ function TablePagination({
           First
         </a>
       </li>
-      {Array.from({ length: numberOfNavLinks }).map((item, i) => (
+      {Array.from({ length: paginationLinksNumber }).map((item, i) => (
         <li
           className={
-            currentPage === i + initialNumberOfNavigationLinks
+            currentPage === i + paginationLinks
               ? 'page-item active'
               : 'page-item'
           }
@@ -136,9 +136,9 @@ function TablePagination({
           <a
             href="#"
             className="page-link"
-            onClick={() => clickHandler(i, initialNumberOfNavigationLinks + i)}
+            onClick={() => clickHandler(i, paginationLinks + i)}
           >
-            {initialNumberOfNavigationLinks + i}
+            {paginationLinks + i}
           </a>
         </li>
       ))}

--- a/src/components/TablePagination.jsx
+++ b/src/components/TablePagination.jsx
@@ -19,11 +19,12 @@ function TablePagination({
     useState(7)
 
   useEffect(() => {
-    const numberOfPages = Number.parseInt(totalLinks / recordsPerPage)
-    const hasRemainer = totalLinks % recordsPerPage ? true : false
-    setTotalNumberOfPages(hasRemainer ? numberOfPages + 1 : numberOfPages)
-    // console.log('max number of pages:', numberOfPages)
-  }, [totalLinks, recordsPerPage])
+    if (totalLinks < maxNumberOfPaginationLinks * recordsPerPage) {
+      setPaginationLinksNumber(Number.parseInt(totalLinks / recordsPerPage) + 1)
+    } else {
+      setPaginationLinksNumber(maxNumberOfPaginationLinks)
+    }
+  }, [maxNumberOfPaginationLinks, recordsPerPage, totalLinks])
 
   const clickHandler = (logicalNavPage, page) => {
     const URL =

--- a/src/components/TablePagination.jsx
+++ b/src/components/TablePagination.jsx
@@ -10,12 +10,14 @@ function TablePagination({
   const [isLoading, setIsLoading] = useState(false)
   const [currentPage, setCurrentPage] = useState(1)
   const [recordsPerPage, setRecordsPerPage] = useState(10)
-  const [totalNumberOfPages, setTotalNumberOfPages] = useState(0)
   const [initialNumberOfNavigationLinks, setInitialNumberOfNavigationLinks] =
     useState(1)
   // const [maxNumberOfPages, setMaxNumberOfPages] = useState(0)
   // const [totalPages, setTotalPages] = useState(0)
   const numberOfNavLinks = 7
+  const [totalNumberOfPages, setTotalNumberOfPages] = useState(
+    Number.parseInt(totalLinks / recordsPerPage) + 1
+  )
 
   useEffect(() => {
     const numberOfPages = Number.parseInt(totalLinks / recordsPerPage)

--- a/src/components/TablePagination.jsx
+++ b/src/components/TablePagination.jsx
@@ -33,12 +33,19 @@ function TablePagination({
 
     setIsLoading(true)
 
-    if (logicalNavPage === numberOfNavLinks - 1 && page < totalNumberOfPages) {
-      setInitialNumberOfNavigationLinks(page - (numberOfNavLinks - 2))
-      setCurrentPage(page)
-    } else if (logicalNavPage === 0 && page !== 1) {
-      setInitialNumberOfNavigationLinks(page - 1)
-      setCurrentPage(page)
+    if (paginationLinksNumber === maxNumberOfPaginationLinks) {
+      if (
+        logicalNavPage === paginationLinksNumber - 1 &&
+        page < totalNumberOfPages
+      ) {
+        setPaginationLinks(page - (paginationLinksNumber - 2))
+        setCurrentPage(page)
+      } else if (logicalNavPage === 0 && page !== 1) {
+        setPaginationLinks(page - 1)
+        setCurrentPage(page)
+      } else {
+        setCurrentPage(page)
+      }
     } else {
       setCurrentPage(page)
     }

--- a/src/components/TablePagination.jsx
+++ b/src/components/TablePagination.jsx
@@ -119,8 +119,8 @@ function TablePagination({
 
   return (
     <ul className="pagination mb-0 justify-content-center">
-        <a href="#" className="page-link">
       <li className={currentPage === 1 ? 'page-item disabled' : 'page-item'}>
+        <a href="#" className="page-link" onClick={() => goToFirst()}>
           First
         </a>
       </li>
@@ -142,7 +142,6 @@ function TablePagination({
           </a>
         </li>
       ))}
-        <a href="#" className="page-link">
       <li
         className={
           currentPage === totalNumberOfPages
@@ -150,6 +149,7 @@ function TablePagination({
             : 'page-item'
         }
       >
+        <a href="#" className="page-link" onClick={() => goToLast()}>
           Last
         </a>
       </li>

--- a/src/components/TablePagination.jsx
+++ b/src/components/TablePagination.jsx
@@ -10,8 +10,6 @@ function TablePagination({
   const [isLoading, setIsLoading] = useState(false)
   const [currentPage, setCurrentPage] = useState(1)
   const [recordsPerPage, setRecordsPerPage] = useState(10)
-  // const [maxNumberOfPages, setMaxNumberOfPages] = useState(0)
-  // const [totalPages, setTotalPages] = useState(0)
   const numberOfNavLinks = 7
   const [totalNumberOfPages, setTotalNumberOfPages] = useState(
     Number.parseInt(totalLinks / recordsPerPage) + 1

--- a/src/components/TablePagination.jsx
+++ b/src/components/TablePagination.jsx
@@ -119,8 +119,8 @@ function TablePagination({
 
   return (
     <ul className="pagination mb-0 justify-content-center">
-      <li className="page-item">
         <a href="#" className="page-link">
+      <li className={currentPage === 1 ? 'page-item disabled' : 'page-item'}>
           First
         </a>
       </li>
@@ -142,8 +142,14 @@ function TablePagination({
           </a>
         </li>
       ))}
-      <li className="page-item">
         <a href="#" className="page-link">
+      <li
+        className={
+          currentPage === totalNumberOfPages
+            ? 'page-item disabled'
+            : 'page-item'
+        }
+      >
           Last
         </a>
       </li>

--- a/src/components/TablePagination.jsx
+++ b/src/components/TablePagination.jsx
@@ -10,14 +10,13 @@ function TablePagination({
   const [isLoading, setIsLoading] = useState(false)
   const [currentPage, setCurrentPage] = useState(1)
   const [recordsPerPage, setRecordsPerPage] = useState(10)
-  const [initialNumberOfNavigationLinks, setInitialNumberOfNavigationLinks] =
-    useState(1)
   // const [maxNumberOfPages, setMaxNumberOfPages] = useState(0)
   // const [totalPages, setTotalPages] = useState(0)
   const numberOfNavLinks = 7
   const [totalNumberOfPages, setTotalNumberOfPages] = useState(
     Number.parseInt(totalLinks / recordsPerPage) + 1
   )
+  const [paginationLinks, setPaginationLinks] = useState(1)
 
   useEffect(() => {
     const numberOfPages = Number.parseInt(totalLinks / recordsPerPage)

--- a/src/components/TablePagination.jsx
+++ b/src/components/TablePagination.jsx
@@ -73,6 +73,26 @@ function TablePagination({
       .finally(() => setIsLoading(false))
   }
 
+  const goToLast = () => {
+    const URL =
+      import.meta.env.VITE_BACKEND_ADDRESS +
+      `/website/${website.toLowerCase()}/records/${totalNumberOfPages - 1}}`
+    setIsLoading(true)
+    setCurrentPage(totalNumberOfPages)
+
+    if (paginationLinksNumber === maxNumberOfPaginationLinks) {
+      setPaginationLinks(totalNumberOfPages - (paginationLinksNumber - 1))
+    } else {
+      setPaginationLinks(1)
+    }
+
+    fetch(URL)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => updateInitialTen(data.links))
+      .catch((err) => setIsLoading(false))
+      .finally(() => setIsLoading(false))
+  }
+
   if (isLoading) {
     return (
       <ul className="pagination mb-0 justify-content-center">

--- a/src/components/TablePagination.jsx
+++ b/src/components/TablePagination.jsx
@@ -14,6 +14,7 @@ function TablePagination({
     Number.parseInt(totalLinks / recordsPerPage) + 1
   )
   const [paginationLinks, setPaginationLinks] = useState(1)
+  const [paginationLinksNumber, setPaginationLinksNumber] = useState(1)
   const [maxNumberOfPaginationLinks, setMaxNumberOfPaginationLinks] =
     useState(7)
 

--- a/src/components/TablePagination.jsx
+++ b/src/components/TablePagination.jsx
@@ -10,11 +10,12 @@ function TablePagination({
   const [isLoading, setIsLoading] = useState(false)
   const [currentPage, setCurrentPage] = useState(1)
   const [recordsPerPage, setRecordsPerPage] = useState(10)
-  const numberOfNavLinks = 7
   const [totalNumberOfPages, setTotalNumberOfPages] = useState(
     Number.parseInt(totalLinks / recordsPerPage) + 1
   )
   const [paginationLinks, setPaginationLinks] = useState(1)
+  const [maxNumberOfPaginationLinks, setMaxNumberOfPaginationLinks] =
+    useState(7)
 
   useEffect(() => {
     const numberOfPages = Number.parseInt(totalLinks / recordsPerPage)

--- a/src/components/TablePagination.jsx
+++ b/src/components/TablePagination.jsx
@@ -57,6 +57,22 @@ function TablePagination({
       .finally(() => setIsLoading(false))
   }
 
+  const goToFirst = () => {
+    const URL =
+      import.meta.env.VITE_BACKEND_ADDRESS +
+      `/website/${website.toLowerCase()}/records/0}`
+
+    setIsLoading(true)
+    setCurrentPage(1)
+    setPaginationLinks(1)
+
+    fetch(URL)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => updateInitialTen(data.links))
+      .catch((err) => setIsLoading(false))
+      .finally(() => setIsLoading(false))
+  }
+
   if (isLoading) {
     return (
       <ul className="pagination mb-0 justify-content-center">


### PR DESCRIPTION
Pagination was a pending subject when the project was committed to GitHub. It wasn't working properly and its features weren't fully implemented yet. This PR fixes & fully implements the pending features that were missing.

### What has been fixed?
The pagination now works as intended without the odd behavior of displaying pages that don't fit the total amount of records.

### What has been implemented?
Both pagination buttons, _First_ & _Last_, now work as intended. Specialized functions have been created for each one of them.

### What else has changed?
- Renamed various variables to make code intent clearer
- Add code to `<li>` elements to handle a `disabled` class when they are the active page