### PR TITLE
Fix broken references

### DIFF
--- a/src/components/SinglePostTableRow.jsx
+++ b/src/components/SinglePostTableRow.jsx
@@ -20,7 +20,7 @@ function SinglePostTableRow({ data }) {
           Link
         </a>
       </td>
-      <td>{data.scrap_index[0].scrapped_on}</td>
+      <td>{data.scrape_index[0].scraped_on}</td>
       <td>
         {nsfwVisibility ? (
           <img src={data.promo_image_src} />
@@ -28,7 +28,7 @@ function SinglePostTableRow({ data }) {
           <img src={data.promo_image_src} className="censored" />
         )}
       </td>
-      <td>{data.scrap_index.length}</td>
+      <td>{data.scrape_index.length}</td>
       <td>
         <a
           href={`/website/${website}/record/${data.index}`}

--- a/src/components/SingleRecord.jsx
+++ b/src/components/SingleRecord.jsx
@@ -96,11 +96,11 @@ function SingleRecord() {
         <div className="flex-fill">
           <p className="text-center fw-bold mb-1">Record Number:</p>
           <p className="text-center">{recordData.index}</p>
-          <p className="text-center fw-bold mb-1">First Appeneded on:</p>
+          <p className="text-center fw-bold mb-1">First Appended on:</p>
           <p className="text-center">{recordData.created_on}</p>
-          <p className="text-center fw-bold mb-1">Total Scrapped Sets:</p>
+          <p className="text-center fw-bold mb-1">Total Scraped Sets:</p>
           <p className="text-center">{recordData.scrape_index.length}</p>
-          <p className="text-center fw-bold mb-1">Latest Scrapped Date:</p>
+          <p className="text-center fw-bold mb-1">Latest Scraped Date:</p>
           <p className="text-center">
             {recordData.scrape_index[0].scraped_on}
           </p>
@@ -114,14 +114,14 @@ function SingleRecord() {
               <i className="bi bi-box-arrow-up-right"></i>
             </a>
             <button className="btn btn-light">
-              <b>Scrap&nbsp;</b>
+              <b>Scrape&nbsp;</b>
               <i className="bi bi-plus-circle-fill"></i>
             </button>
           </p>
         </div>
       </div>
       <div className="card-footer p-0">
-        <SingleRecordTable scrappedRecords={recordData.scrape_index} />
+        <SingleRecordTable scrapedRecords={recordData.scrape_index} />
       </div>
     </div>
   )

--- a/src/components/SingleRecord.jsx
+++ b/src/components/SingleRecord.jsx
@@ -99,9 +99,11 @@ function SingleRecord() {
           <p className="text-center fw-bold mb-1">First Appeneded on:</p>
           <p className="text-center">{recordData.created_on}</p>
           <p className="text-center fw-bold mb-1">Total Scrapped Sets:</p>
-          <p className="text-center">{recordData.scrap_index.length}</p>
+          <p className="text-center">{recordData.scrape_index.length}</p>
           <p className="text-center fw-bold mb-1">Latest Scrapped Date:</p>
-          <p className="text-center">{recordData.scrap_index[0].scrapped_on}</p>
+          <p className="text-center">
+            {recordData.scrape_index[0].scraped_on}
+          </p>
           <p className="text-center">
             <a
               href={recordData.link}
@@ -119,7 +121,7 @@ function SingleRecord() {
         </div>
       </div>
       <div className="card-footer p-0">
-        <SingleRecordTable scrappedRecords={recordData.scrap_index} />
+        <SingleRecordTable scrappedRecords={recordData.scrape_index} />
       </div>
     </div>
   )

--- a/src/components/SingleRecordTable.jsx
+++ b/src/components/SingleRecordTable.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import SingleRecordTableRow from './SingleRecordTableRow'
 
-function SingleRecordTable({ scrappedRecords }) {
+function SingleRecordTable({ scrapedRecords }) {
   const [isLoading, setIsLoading] = useState(false)
 
   return (
@@ -9,12 +9,12 @@ function SingleRecordTable({ scrappedRecords }) {
       <thead>
         <tr>
           <th>Index:</th>
-          <th>Scrapped On:</th>
-          <th>Scrapped Set:</th>
+          <th>Scraped On:</th>
+          <th>Scraped Set:</th>
         </tr>
       </thead>
       <tbody>
-        {scrappedRecords.map((recordData, i) => (
+        {scrapedRecords.map((recordData, i) => (
           <SingleRecordTableRow recordData={recordData} index={i} />
         ))}
       </tbody>

--- a/src/components/SingleRecordTableRow.jsx
+++ b/src/components/SingleRecordTableRow.jsx
@@ -2,13 +2,13 @@ function SingleRecordTableRow({ recordData, index }) {
   const emptyArray = Array.from({ length: 4 }, () => 0)
 
   const filledArray = emptyArray.map((value, i) => {
-    if (recordData.scrapped_entries[i]) return recordData.scrapped_entries[i]
+    if (recordData.scraped_entries[i]) return recordData.scraped_entries[i]
     else return value
   })
   return (
     <tr>
       <td>{index}</td>
-      <td>{recordData.scrapped_on}</td>
+      <td>{recordData.scraped_on}</td>
       <td>
         <table className="table table-sm nested-table mb-0">
           <tr>


### PR DESCRIPTION
This PR fixes the issue #4 that was provoked by broken references caused by correcting the typo `scrapped` on a recent version of the back-end part of the project.

### Important changes
- Fix the typo `scrapped` off of inline text elements
- Fix the typo `scrapped` used as an object property